### PR TITLE
TAP-2934 fix(tapdata-api): Multiple tasks report the same error

### DIFF
--- a/plugin-kit/tapdata-api/src/main/java/io/tapdata/entity/codec/filter/TapCodecsFilterManager.java
+++ b/plugin-kit/tapdata-api/src/main/java/io/tapdata/entity/codec/filter/TapCodecsFilterManager.java
@@ -115,6 +115,8 @@ public class TapCodecsFilterManager {
                                 valueCodec = null;
                                 newField = true;
                             }
+                        } else {
+                            newField = true;
                         }
                     } else {
                         newField = true;


### PR DESCRIPTION
can't find a codec for CodecCacheKey{clazz=class io.tapdata.entity.schema.value.TapStringValue, types=null}

Closes TAP-2934