### PR TITLE
fix: TAP-5651 mysql -> mysql sync index error: BLOB/TEXT column 'Code…

### DIFF
--- a/plugin-kit/tapdata-api/src/main/java/io/tapdata/entity/schema/TapIndexField.java
+++ b/plugin-kit/tapdata-api/src/main/java/io/tapdata/entity/schema/TapIndexField.java
@@ -27,6 +27,16 @@ public class TapIndexField implements Serializable {
         return this;
     }
 
+    private Integer subPart;
+
+    public Integer getSubPart() {
+        return subPart;
+    }
+
+    public void setSubPart(Integer subPart) {
+        this.subPart = subPart;
+    }
+
     public Boolean getFieldAsc() {
         return fieldAsc;
     }
@@ -45,7 +55,7 @@ public class TapIndexField implements Serializable {
 
     @Override
     public String toString() {
-        return "TapIndexField name " + name + " fieldAsc " + fieldAsc + " indexType " + type;
+        return "TapIndexField name " + name + " fieldAsc " + fieldAsc + " indexType " + type + " subPart " + subPart;
     }
 
     public String getType() {


### PR DESCRIPTION
…' used in key specification without a key length