### PR TITLE
Fix(proxy): TAP-10588 support gateway HA routing

### DIFF
--- a/plugin-kit/tapdata-modules/modules-api/src/main/java/io/tapdata/modules/api/net/entity/NodeRegistry.java
+++ b/plugin-kit/tapdata-modules/modules-api/src/main/java/io/tapdata/modules/api/net/entity/NodeRegistry.java
@@ -8,10 +8,13 @@ import java.util.List;
 
 public class NodeRegistry {
 	private List<String> ips;
+	private String instanceId;
+
 	public NodeRegistry ip(String ip) {
 		if(ips == null)
 			ips = new ArrayList<>();
 		ips.add(ip);
+		cachedId = null;
 		return this;
 	}
 	public NodeRegistry ips(List<String> ips) {
@@ -23,24 +26,29 @@ public class NodeRegistry {
 					this.ips.add(newIp);
 				}
 			}
+			cachedId = null;
 			return this;
 		}
-		this.ips = ips;
+		this.ips = new ArrayList<>(ips);
+		cachedId = null;
 		return this;
 	}
 	private Integer wsPort;
 	public NodeRegistry wsPort(Integer wsPort) {
 		this.wsPort = wsPort;
+		cachedId = null;
 		return this;
 	}
 	private Integer httpPort;
 	public NodeRegistry httpPort(Integer httpPort) {
 		this.httpPort = httpPort;
+		cachedId = null;
 		return this;
 	}
 	private String type;
 	public NodeRegistry type(String type) {
 		this.type = type;
+		cachedId = null;
 		return this;
 	}
 	private Long time;
@@ -48,10 +56,15 @@ public class NodeRegistry {
 		this.time = time;
 		return this;
 	}
+	public NodeRegistry instanceId(String instanceId) {
+		this.instanceId = instanceId;
+		cachedId = null;
+		return this;
+	}
 
 	@Override
 	public String toString() {
-		return "NodeRegistry ips " + ips + " httpPort " + httpPort + " wsPort " + wsPort + " type " + type + " time " + (time != null ? new Date(time) : null) + "; ";
+		return "NodeRegistry instanceId " + instanceId + " ips " + ips + " httpPort " + httpPort + " wsPort " + wsPort + " type " + type + " time " + (time != null ? new Date(time) : null) + "; ";
 	}
 
 //	@Override
@@ -79,7 +92,8 @@ public class NodeRegistry {
 	}
 
 	public void setIps(List<String> ips) {
-		this.ips = ips;
+		this.ips = ips != null ? new ArrayList<>(ips) : null;
+		cachedId = null;
 	}
 
 	public Integer getWsPort() {
@@ -88,6 +102,7 @@ public class NodeRegistry {
 
 	public void setWsPort(Integer wsPort) {
 		this.wsPort = wsPort;
+		cachedId = null;
 	}
 
 	public Integer getHttpPort() {
@@ -96,6 +111,7 @@ public class NodeRegistry {
 
 	public void setHttpPort(Integer httpPort) {
 		this.httpPort = httpPort;
+		cachedId = null;
 	}
 
 	private volatile String cachedId = null;
@@ -103,10 +119,16 @@ public class NodeRegistry {
 		if(cachedId == null) {
 			synchronized (this) {
 				if(cachedId == null) {
-					List<String> strings = new ArrayList<>(ips);
-					strings.add(String.valueOf(httpPort));
-					strings.add(String.valueOf(wsPort));
-					strings.add(type);
+					List<String> strings = new ArrayList<>();
+					if(instanceId != null && !instanceId.trim().isEmpty()) {
+						strings.add(instanceId);
+					} else {
+						if(ips != null)
+							strings.addAll(ips);
+						strings.add(String.valueOf(httpPort));
+						strings.add(String.valueOf(wsPort));
+						strings.add(type);
+					}
 					cachedId = APIUtils.idForList(strings);
 				}
 			}
@@ -120,6 +142,7 @@ public class NodeRegistry {
 
 	public void setType(String type) {
 		this.type = type;
+		cachedId = null;
 	}
 
 	public Long getTime() {
@@ -128,6 +151,15 @@ public class NodeRegistry {
 
 	public void setTime(Long time) {
 		this.time = time;
+	}
+
+	public String getInstanceId() {
+		return instanceId;
+	}
+
+	public void setInstanceId(String instanceId) {
+		this.instanceId = instanceId;
+		cachedId = null;
 	}
 
 }

--- a/plugin-kit/tapdata-modules/modules-api/src/test/java/io/tapdata/modules/api/net/entity/NodeRegistryTest.java
+++ b/plugin-kit/tapdata-modules/modules-api/src/test/java/io/tapdata/modules/api/net/entity/NodeRegistryTest.java
@@ -1,0 +1,58 @@
+package io.tapdata.modules.api.net.entity;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+public class NodeRegistryTest {
+
+	@Test
+	void idShouldKeepCompatibleWhenInstanceIdMissing() {
+		NodeRegistry first = new NodeRegistry()
+				.ips(Arrays.asList("127.0.0.1", "192.168.0.10"))
+				.httpPort(3000)
+				.wsPort(8246)
+				.type("proxy");
+		NodeRegistry second = new NodeRegistry()
+				.ips(Arrays.asList("127.0.0.1", "192.168.0.10"))
+				.httpPort(3000)
+				.wsPort(8246)
+				.type("proxy");
+
+		Assertions.assertEquals(first.id(), second.id());
+	}
+
+	@Test
+	void idShouldUseInstanceIdWhenPresent() {
+		NodeRegistry first = new NodeRegistry()
+				.instanceId("tm-0")
+				.ips(Arrays.asList("127.0.0.1"))
+				.httpPort(3000)
+				.wsPort(8246)
+				.type("proxy");
+		NodeRegistry second = new NodeRegistry()
+				.instanceId("tm-1")
+				.ips(Arrays.asList("127.0.0.1"))
+				.httpPort(3000)
+				.wsPort(8246)
+				.type("proxy");
+
+		Assertions.assertNotEquals(first.id(), second.id());
+	}
+
+	@Test
+	void idShouldStayStableWhenInstanceAddressChanges() {
+		NodeRegistry nodeRegistry = new NodeRegistry()
+				.instanceId("tm-0")
+				.ips(Arrays.asList("127.0.0.1"))
+				.httpPort(3000)
+				.wsPort(8246)
+				.type("proxy");
+		String id = nodeRegistry.id();
+
+		nodeRegistry.ips(Arrays.asList("192.168.0.10")).httpPort(3001).wsPort(8247);
+
+		Assertions.assertEquals(id, nodeRegistry.id());
+	}
+}

--- a/plugin-kit/tapdata-modules/mongodb-storage-module/src/main/java/io/tapdata/mongodb/net/NodeRegistryServiceImpl.java
+++ b/plugin-kit/tapdata-modules/mongodb-storage-module/src/main/java/io/tapdata/mongodb/net/NodeRegistryServiceImpl.java
@@ -19,7 +19,12 @@ public class NodeRegistryServiceImpl implements NodeRegistryService {
 	private NodeRegistryDAO nodeRegistryDAO;
 	@Override
 	public void save(NodeRegistry nodeRegistry) {
-		nodeRegistryDAO.insertOne(new NodeRegistryEntity(nodeRegistry.id(), nodeRegistry));
+		String nodeId = nodeRegistry.id();
+		nodeRegistryDAO.upsertOne(
+				new Document(FIELD_ID, nodeId),
+				new Document("$set", new Document(NodeRegistryEntity.FIELD_NODE, nodeRegistry))
+						.append("$setOnInsert", new Document(FIELD_ID, nodeId))
+		);
 	}
 
 	@Override

--- a/plugin-kit/tapdata-modules/websocket-server-module/src/main/java/io/tapdata/wsserver/channels/gateway/GatewaySessionManager.java
+++ b/plugin-kit/tapdata-modules/websocket-server-module/src/main/java/io/tapdata/wsserver/channels/gateway/GatewaySessionManager.java
@@ -37,6 +37,11 @@ import org.reflections.Reflections;
 import org.reflections.scanners.TypeAnnotationsScanner;
 import org.reflections.util.ConfigurationBuilder;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -159,7 +164,8 @@ public class GatewaySessionManager implements HealthWeightListener, MemoryFetche
         IPHolder ipHolder = new IPHolder();
         ipHolder.init();
         int httpPort = CommonUtils.getPropertyInt("tapdata_proxy_server_port", 3000); //TODO should read from TM config.
-        nodeRegistry = new NodeRegistry().ips(ipHolder.getIps()).httpPort(httpPort).wsPort(webSocketManager.getWebSocketProperties().getPort()).type("proxy").time(System.currentTimeMillis());
+        String instanceId = resolveProxyInstanceId();
+        nodeRegistry = new NodeRegistry().instanceId(instanceId).ips(ipHolder.getIps()).httpPort(httpPort).wsPort(webSocketManager.getWebSocketProperties().getPort()).type("proxy").time(System.currentTimeMillis());
         CommonUtils.setProperty("tapdata_node_id", nodeRegistry.id());
         nodeRegistryService.save(nodeRegistry);
         
@@ -171,6 +177,48 @@ public class GatewaySessionManager implements HealthWeightListener, MemoryFetche
                 nodeConnection.close();
         });
         nodeHealthManager.start(this);
+    }
+
+    private String resolveProxyInstanceId() {
+        String instanceId = CommonUtils.getProperty("tapdata_proxy_instance_id");
+        if(StringUtils.isNotBlank(instanceId))
+            return instanceId.trim();
+
+        instanceId = System.getenv("POD_NAME");
+        if(StringUtils.isNotBlank(instanceId))
+            return instanceId.trim();
+
+        instanceId = System.getenv("HOSTNAME");
+        if(StringUtils.isNotBlank(instanceId))
+            return instanceId.trim();
+
+        Path path = resolveProxyInstanceIdPath();
+        try {
+            if(Files.exists(path)) {
+                String saved = new String(Files.readAllBytes(path), StandardCharsets.UTF_8).trim();
+                if(StringUtils.isNotBlank(saved))
+                    return saved;
+            }
+            String generated = UUID.randomUUID().toString().replace("-", "");
+            Path parent = path.getParent();
+            if(parent != null)
+                Files.createDirectories(parent);
+            Files.write(path, generated.getBytes(StandardCharsets.UTF_8));
+            return generated;
+        } catch (IOException e) {
+            TapLogger.warn(TAG, "Resolve proxy instance id from {} failed, use process unique id, {}", path, e.getMessage());
+            return CommonUtils.processUniqueId();
+        }
+    }
+
+    private Path resolveProxyInstanceIdPath() {
+        String path = CommonUtils.getProperty("tapdata_proxy_instance_id_file");
+        if(StringUtils.isNotBlank(path))
+            return Paths.get(path);
+        String workDir = System.getenv("TAPDATA_WORK_DIR");
+        if(StringUtils.isBlank(workDir))
+            workDir = System.getProperty("user.dir", ".");
+        return Paths.get(workDir, ".proxy-instance-id");
     }
 
     private void handleScanRoomSessionState(GatewaySessionManager gatewaySessionManager, StateMachine<Integer, GatewaySessionManager> integerGatewaySessionManagerStateMachine) {

--- a/plugin-kit/tapdata-modules/websocket-server-module/src/main/java/io/tapdata/wsserver/channels/gateway/modules/GatewayChannelModule.java
+++ b/plugin-kit/tapdata-modules/websocket-server-module/src/main/java/io/tapdata/wsserver/channels/gateway/modules/GatewayChannelModule.java
@@ -112,6 +112,7 @@ public class GatewayChannelModule implements MemoryFetcher {
             String nodeId = (String) claims.get("nodeId");
             String userId = (String) claims.get("uid");
             String currentNodeId = CommonUtils.getProperty("tapdata_node_id");
+            TapLogger.info(TAG, "Gateway identity received, service {}, clientId {}, issuedNodeId {}, connectedNodeId {}, uid {}", service, clientId, nodeId, currentNodeId, userId);
 //            if(currentNodeId != null && !currentNodeId.equals(nodeId)) {
 //                identityReceivedEvent.closeChannel(identity.getId(), WSErrors.ERROR_WRONG_NODE, FormatUtils.format("Visited wrong node {}, current node is {}", nodeId, currentNodeId));
 //                return;

--- a/plugin-kit/tapdata-modules/websocket-server-module/src/main/java/io/tapdata/wsserver/channels/health/NodeHealthManager.java
+++ b/plugin-kit/tapdata-modules/websocket-server-module/src/main/java/io/tapdata/wsserver/channels/health/NodeHealthManager.java
@@ -12,6 +12,7 @@ import io.tapdata.modules.api.net.error.NetErrors;
 import io.tapdata.modules.api.net.service.node.NodeHealthService;
 import io.tapdata.modules.api.net.service.node.NodeRegistryService;
 import io.tapdata.modules.api.net.service.ProxySubscriptionService;
+import io.tapdata.modules.api.net.service.node.connection.NodeConnection;
 import io.tapdata.modules.api.net.service.node.connection.NodeConnectionFactory;
 import io.tapdata.pdk.core.executor.ExecutorsManager;
 import io.tapdata.pdk.core.utils.CommonUtils;
@@ -135,6 +136,18 @@ public class NodeHealthManager implements MemoryFetcher {
 					NodeHealth existingNodeHealth = existingNodeHandler.getNodeHealth();
 					if(existingNodeHealth != null)
 						existingNodeHealth.clone(nodeHealth);
+					NodeRegistry latestNodeRegistry = nodeRegistryService.get(nodeHealth.getId());
+					if(latestNodeRegistry != null) {
+						NodeRegistry oldNodeRegistry = existingNodeHandler.getNodeRegistry();
+						existingNodeHandler.setNodeRegistry(latestNodeRegistry);
+						if(registryConnectionInfoChanged(oldNodeRegistry, latestNodeRegistry)) {
+							NodeConnection nodeConnection = nodeConnectionFactory.removeNodeConnection(nodeHealth.getId());
+							if(nodeConnection != null)
+								nodeConnection.close();
+							if(newNodeConsumer != null)
+								newNodeConsumer.accept(latestNodeRegistry);
+						}
+					}
 				}
 				if(newAdded.get() != null && newNodeConsumer != null) {
 					newNodeConsumer.accept(newAdded.get());
@@ -160,6 +173,18 @@ public class NodeHealthManager implements MemoryFetcher {
 				}
 			}
 		}
+	}
+
+	private boolean registryConnectionInfoChanged(NodeRegistry oldNodeRegistry, NodeRegistry latestNodeRegistry) {
+		if(oldNodeRegistry == latestNodeRegistry)
+			return false;
+		if(oldNodeRegistry == null || latestNodeRegistry == null)
+			return true;
+		return !Objects.equals(oldNodeRegistry.getInstanceId(), latestNodeRegistry.getInstanceId())
+				|| !Objects.equals(oldNodeRegistry.getIps(), latestNodeRegistry.getIps())
+				|| !Objects.equals(oldNodeRegistry.getHttpPort(), latestNodeRegistry.getHttpPort())
+				|| !Objects.equals(oldNodeRegistry.getWsPort(), latestNodeRegistry.getWsPort())
+				|| !Objects.equals(oldNodeRegistry.getType(), latestNodeRegistry.getType());
 	}
 
 	public boolean isNodeAlive(String nodeId) {

--- a/plugin-kit/tapdata-proxy/src/main/java/io/tapdata/proxy/EngineMessageExecutionServiceImpl.java
+++ b/plugin-kit/tapdata-proxy/src/main/java/io/tapdata/proxy/EngineMessageExecutionServiceImpl.java
@@ -189,23 +189,30 @@ public class EngineMessageExecutionServiceImpl implements EngineMessageExecution
 		}
 
 		Throwable error = null;
-		if(!list.isEmpty()) {
-			RandomDraw randomDraw = new RandomDraw(list.size());
+		List<String> availableNodeIds = availableNodeIds(list);
+		if(!availableNodeIds.isEmpty()) {
+			RandomDraw randomDraw = new RandomDraw(availableNodeIds.size());
 			int index;
 			while ((index = randomDraw.next()) != -1) {
-				String id = list.get(index);
+				String id = availableNodeIds.get(index);
 				NodeConnection nodeConnection = nodeConnectionFactory.getNodeConnection(id);
-				if (nodeConnection != null && nodeConnection.isReady() && nodeHealthManager.getAliveNode(id) != null) {
-					try {
-						engineMessage.setOtherTMIpPort(nodeConnection.getWorkingIpPort());
-						//noinspection unchecked
-						T response = nodeConnection.send(type, engineMessage, tClass);
-						biConsumer.accept(response, null);
-						return;
-					} catch (Throwable ioException) {
-						TapLogger.info(TAG, "Send to nodeId {} failed {} and will try next, command {}", id, ioException.getMessage(), engineMessage);
-						error = ioException;
-					}
+				if(nodeConnection == null) {
+					TapLogger.debug(TAG, "Skip nodeId {} because connection is null", id);
+					continue;
+				}
+				if(!waitConnectionReady(id, nodeConnection)) {
+					error = new CoreException(NetErrors.NO_AVAILABLE_ENGINE, "Node connection is not ready for nodeId " + id);
+					continue;
+				}
+				try {
+					engineMessage.setOtherTMIpPort(nodeConnection.getWorkingIpPort());
+					//noinspection unchecked
+					T response = nodeConnection.send(type, engineMessage, tClass);
+					biConsumer.accept(response, null);
+					return;
+				} catch (Throwable ioException) {
+					TapLogger.info(TAG, "Send to nodeId {} failed {} and will try next, command {}", id, ioException.getMessage(), engineMessage);
+					error = ioException;
 				}
 			}
 		}
@@ -214,6 +221,50 @@ public class EngineMessageExecutionServiceImpl implements EngineMessageExecution
 		} else {
 			biConsumer.accept(null, new CoreException(NetErrors.NO_AVAILABLE_ENGINE, "No available engine"));
 		}
+	}
+
+	private List<String> availableNodeIds(List<String> nodeIds) {
+		List<String> availableNodeIds = new ArrayList<>();
+		if(nodeIds == null)
+			return availableNodeIds;
+		for(String nodeId : nodeIds) {
+			if(nodeId == null)
+				continue;
+			NodeHandler nodeHandler = nodeHealthManager.getAliveNode(nodeId);
+			if(nodeHandler == null || nodeHandler.getNodeHealth() == null) {
+				TapLogger.debug(TAG, "Skip nodeId {} because it is not alive", nodeId);
+				continue;
+			}
+			NodeHealth nodeHealth = nodeHandler.getNodeHealth();
+			if(nodeHealth.getOnline() == null || nodeHealth.getOnline() <= 0) {
+				TapLogger.debug(TAG, "Skip nodeId {} because online count is {}", nodeId, nodeHealth.getOnline());
+				continue;
+			}
+			NodeConnection nodeConnection = nodeConnectionFactory.getNodeConnection(nodeId);
+			if(nodeConnection == null) {
+				TapLogger.debug(TAG, "Skip nodeId {} because connection is null", nodeId);
+				continue;
+			}
+			availableNodeIds.add(nodeId);
+		}
+		return availableNodeIds;
+	}
+
+	private boolean waitConnectionReady(String nodeId, NodeConnection nodeConnection) {
+		int waitMillis = CommonUtils.getPropertyInt("tapdata_node_connection_ready_wait_millis", 5000);
+		long deadline = System.currentTimeMillis() + waitMillis;
+		while(!nodeConnection.isReady() && System.currentTimeMillis() < deadline) {
+			try {
+				Thread.sleep(50L);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				return false;
+			}
+		}
+		boolean ready = nodeConnection.isReady();
+		if(!ready)
+			TapLogger.debug(TAG, "Skip nodeId {} because connection is not ready after {} ms, connection {}", nodeId, waitMillis, nodeConnection);
+		return ready;
 	}
 
 	@Override


### PR DESCRIPTION
Use a stable proxy instance id for node registry identity so multiple TM instances behind the same address do not overwrite each other.

Register proxy nodes with upsert semantics, refresh cached registry connection data for existing healthy nodes, and keep websocket identity acceptance independent from the token issuing node while logging issued and connected node ids.

Filter remote engine message candidates by node health, online count, and ready node connection before attempting cross-TM forwarding.

Refs: TAP-10588